### PR TITLE
Adjust layout and robot visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,26 +39,28 @@
         </div>
       </div>
 
-      <div class="stats-panel">
-        <h2>Status</h2>
-        <div class="stat-card">
-          <span class="label">Aktuell episod</span>
-          <span class="value" id="episodeCounter">0</span>
+      <div class="side-panel">
+        <div class="stats-panel">
+          <h2>Status</h2>
+          <div class="stat-card">
+            <span class="label">Aktuell episod</span>
+            <span class="value" id="episodeCounter">0</span>
+          </div>
+          <div class="stat-card">
+            <span class="label">Poäng denna episod</span>
+            <span class="value" id="currentScore">0</span>
+          </div>
+          <div class="stat-card highlight">
+            <span class="label">Högsta poäng hittills</span>
+            <span class="value" id="bestScore">0</span>
+          </div>
         </div>
-        <div class="stat-card">
-          <span class="label">Poäng denna episod</span>
-          <span class="value" id="currentScore">0</span>
-        </div>
-        <div class="stat-card highlight">
-          <span class="label">Högsta poäng hittills</span>
-          <span class="value" id="bestScore">0</span>
-        </div>
-      </div>
-    </section>
 
-    <section class="chart-section">
-      <h2>Poäng per runda</h2>
-      <canvas id="scoreChart" height="160"></canvas>
+        <section class="chart-section">
+          <h2>Poäng per runda</h2>
+          <canvas id="scoreChart" height="160"></canvas>
+        </section>
+      </div>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -173,8 +173,6 @@ function updateRobotVisual() {
   const robotSpan = document.createElement("span");
   robotSpan.className = "robot-icon";
   robotSpan.textContent = "🤖";
-  robotSpan.style.position = "absolute";
-  robotSpan.style.fontSize = "1.6rem";
   cell.appendChild(robotSpan);
 }
 

--- a/style.css
+++ b/style.css
@@ -98,9 +98,18 @@ button.danger {
 
 .dashboard {
   display: grid;
-  grid-template-columns: 1.3fr 1fr;
-  gap: 2rem;
+  grid-template-columns: 1.2fr auto;
+  gap: 1.5rem;
+  align-items: start;
   margin-bottom: 2rem;
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 260px;
+  width: 100%;
 }
 
 .grid-panel,
@@ -123,16 +132,16 @@ button.danger {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   grid-template-rows: repeat(5, 1fr);
-  gap: 6px;
+  gap: 2px;
   margin-top: 1rem;
 }
 
 .cell {
   position: relative;
-  width: 70px;
-  height: 70px;
+  width: 68px;
+  height: 68px;
   background: white;
-  border-radius: 18px;
+  border-radius: 14px;
   border: 2px solid var(--grid-line);
   display: flex;
   align-items: center;
@@ -178,13 +187,14 @@ button.danger {
 
 .stats-panel {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
+  padding: 1.25rem;
 }
 
 .stat-card {
-  background: rgba(255, 255, 255, 0.8);
-  padding: 1rem 1.2rem;
-  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
   border: 1px solid rgba(125, 138, 230, 0.18);
   display: flex;
   justify-content: space-between;
@@ -202,7 +212,7 @@ button.danger {
 }
 
 .stat-card .value {
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 700;
   color: var(--text);
 }
@@ -210,13 +220,34 @@ button.danger {
 .chart-section {
   background: var(--panel);
   border-radius: 24px;
-  padding: 1.5rem;
+  padding: 1.25rem;
   box-shadow: 0 10px 30px rgba(45, 70, 100, 0.1);
+  height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-section canvas {
+  width: 100% !important;
+  height: 150px !important;
+}
+
+.robot-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
 }
 
 @media (max-width: 960px) {
   .dashboard {
     grid-template-columns: 1fr;
+  }
+
+  .side-panel {
+    max-width: none;
   }
 
   .grid {


### PR DESCRIPTION
## Summary
- place the score chart beside the grid inside a new side panel and shrink its height
- tighten the grid spacing and reduce the status panel sizing for a more compact layout
- center the robot icon within cells to ensure purely orthogonal movement visuals

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d537ce33d4832b971accc21e0886b0