### PR TITLE
Adjust layout, speed control, and chart sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
         <button id="resetBtn" class="danger">Starta om</button>
       </div>
       <div class="speed-control">
-        <label for="speedSlider">Hastighet: <span id="speedLabel">Medium</span></label>
-        <input type="range" id="speedSlider" min="1" max="5" value="3" />
+        <label for="speedSlider">Hastighet: <span id="speedLabel">Bas</span></label>
+        <input type="range" id="speedSlider" min="1" max="10" value="1" />
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@
   --text: #2f2a4a;
   --grid-line: #d4c5f0;
   --highlight: #ffd166;
+  --cell-size: 68px;
   font-size: 16px;
 }
 
@@ -100,7 +101,7 @@ button.danger {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
   gap: 1.5rem;
-  align-items: start;
+  align-items: stretch;
   margin-bottom: 2rem;
 }
 
@@ -108,8 +109,9 @@ button.danger {
   display: flex;
   align-items: stretch;
   justify-content: flex-start;
-  max-width: 400px;
+  max-width: 420px;
   width: 100%;
+  height: 100%;
 }
 
 .grid-panel {
@@ -135,16 +137,18 @@ button.danger {
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(5, 1fr);
+  grid-template-columns: repeat(5, var(--cell-size));
+  grid-auto-rows: var(--cell-size);
   gap: 2px;
   margin-top: 1rem;
+  justify-content: center;
+  justify-items: stretch;
 }
 
 .cell {
   position: relative;
-  width: 68px;
-  height: 68px;
+  width: var(--cell-size);
+  height: var(--cell-size);
   background: white;
   border-radius: 14px;
   border: 2px solid var(--grid-line);
@@ -175,6 +179,7 @@ button.danger {
 
 .status-panel {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.75rem;
   padding: 1.25rem;
   background: rgba(255, 255, 255, 0.82);
@@ -233,15 +238,14 @@ button.danger {
   box-shadow: 0 10px 30px rgba(45, 70, 100, 0.1);
   display: flex;
   flex-direction: column;
-  width: min(100%, 360px);
-  min-height: 280px;
-  max-height: 340px;
+  width: min(100%, 380px);
+  height: 100%;
   flex: 1;
 }
 
 .chart-section canvas {
-  width: 100% !important;
-  height: 100% !important;
+  width: 100%;
+  height: 100%;
   flex: 1;
   min-height: 0;
 }
@@ -265,17 +269,13 @@ button.danger {
     justify-content: center;
   }
 
-  .chart-section {
-    width: min(100%, 420px);
-  }
-
   .grid {
     margin: 0 auto;
+    --cell-size: 60px;
   }
 
-  .cell {
-    width: 60px;
-    height: 60px;
+  .chart-section {
+    width: min(100%, 440px);
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the game board grid spacing and arrange status cards side-by-side
- scale the chart container to match the playfield height and keep it responsive
- make the former medium speed the default and allow up to a 10× speed through the slider

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5413b2ef4832babb56d80d5325eb6