### PR TITLE
Add version history and adjust layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Förstärkningsinlärning – Gridvärld</title>
+  <title>Förstärkningsinlärning – Gridvärld v 1.1</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <main class="app-container">
     <header>
-      <h1>Robotens förstärkningsinlärning</h1>
+      <h1>Robotens förstärkningsinlärning v 1.1</h1>
       <p>Utforska hur en enkel Q-learning agent hittar den optimala vägen genom rutnätet.</p>
     </header>
 
@@ -28,7 +28,6 @@
 
     <section class="dashboard">
       <div class="grid-panel">
-        <h2>Spelplan</h2>
         <div id="grid" class="grid"></div>
         <div class="legend">
           <span><span class="legend-icon start">🏠</span>Start</span>
@@ -38,7 +37,6 @@
           <span><span class="legend-icon robot">🤖</span>Robot</span>
         </div>
         <div class="status-panel">
-          <h2>Status</h2>
           <div class="stat-card">
             <span class="label">Aktuell episod</span>
             <span class="value" id="episodeCounter">0</span>
@@ -60,6 +58,14 @@
           <canvas id="scoreChart"></canvas>
         </section>
       </div>
+    </section>
+
+    <section class="version-history">
+      <h2>Versionshistorik</h2>
+      <ul>
+        <li><strong>v 1.1:</strong> Förbättrad layout, korrigerad belöningshantering och tillagd versionslogg.</li>
+        <li><strong>v 1.0:</strong> Första versionen med visualisering av Q-learning i gridvärlden.</li>
+      </ul>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -249,10 +249,10 @@ function takeStep(action) {
   let done = false;
 
   if (nextRow === goalPos.row && nextCol === goalPos.col) {
-    reward = 10;
+    reward += 10;
     done = true;
   } else if (nextRow === hazardPos.row && nextCol === hazardPos.col) {
-    reward = -10;
+    reward -= 10;
     done = true;
   }
 

--- a/style.css
+++ b/style.css
@@ -120,19 +120,15 @@ button.danger {
   padding: 1.5rem;
   box-shadow: 0 10px 30px rgba(45, 70, 100, 0.1);
   backdrop-filter: blur(8px);
-}
-
-.grid-panel h2,
-.status-panel h2,
-.chart-section h2 {
-  margin-top: 0;
-  color: var(--accent);
-}
-
-.grid-panel {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.grid-panel h2,
+.chart-section h2 {
+  margin-top: 0;
+  color: var(--accent);
 }
 
 .grid {
@@ -140,8 +136,7 @@ button.danger {
   grid-template-columns: repeat(5, var(--cell-size));
   grid-auto-rows: var(--cell-size);
   gap: 2px;
-  margin-top: 1rem;
-  justify-content: center;
+  justify-content: start;
   justify-items: stretch;
 }
 
@@ -178,14 +173,16 @@ button.danger {
 }
 
 .status-panel {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  display: flex;
   gap: 0.75rem;
   padding: 1.25rem;
   background: rgba(255, 255, 255, 0.82);
   border-radius: 20px;
   border: 1px solid rgba(125, 138, 230, 0.18);
   box-shadow: inset 0 2px 6px rgba(125, 138, 230, 0.08);
+  align-items: stretch;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .legend-icon {
@@ -214,6 +211,7 @@ button.danger {
   justify-content: space-between;
   align-items: baseline;
   box-shadow: inset 0 2px 6px rgba(125, 138, 230, 0.08);
+  flex: 1 1 180px;
 }
 
 .stat-card.highlight {
@@ -259,6 +257,31 @@ button.danger {
   font-size: 1.6rem;
 }
 
+.version-history {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 20px rgba(45, 70, 100, 0.08);
+}
+
+.version-history h2 {
+  margin-top: 0;
+  color: var(--accent);
+}
+
+.version-history ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: rgba(47, 42, 74, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.version-history li strong {
+  color: var(--accent);
+}
+
 @media (max-width: 960px) {
   .dashboard {
     grid-template-columns: 1fr;
@@ -270,7 +293,7 @@ button.danger {
   }
 
   .grid {
-    margin: 0 auto;
+    margin: 0;
     --cell-size: 60px;
   }
 


### PR DESCRIPTION
## Summary
- add version v 1.1 labeling and a versionshistorik section to the interface
- adjust the layout to place the grid at the top-left and align the score cards on one row
- ensure the goal reward still applies the step penalty so the maximum score caps at 9.2

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d54c3e4aa4832ba399ef493e14e705