### PR TITLE
Add epsilon display and show best route overlay when paused

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Förstärkningsinlärning – Gridvärld v 1.1</title>
+  <title>Förstärkningsinlärning – Gridvärld v 1.2</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <main class="app-container">
     <header>
-      <h1>Robotens förstärkningsinlärning v 1.1</h1>
+      <h1>Robotens förstärkningsinlärning v 1.2</h1>
       <p>Utforska hur en enkel Q-learning agent hittar den optimala vägen genom rutnätet.</p>
     </header>
 
@@ -28,7 +28,10 @@
 
     <section class="dashboard">
       <div class="grid-panel">
-        <div id="grid" class="grid"></div>
+        <div class="grid-wrapper" id="gridWrapper">
+          <div id="grid" class="grid"></div>
+          <svg id="pathOverlay" class="path-overlay" preserveAspectRatio="none"></svg>
+        </div>
         <div class="legend">
           <span><span class="legend-icon start">🏠</span>Start</span>
           <span><span class="legend-icon goal">💎</span>Mål</span>
@@ -45,9 +48,15 @@
             <span class="label">Poäng denna episod</span>
             <span class="value" id="currentScore">0</span>
           </div>
-          <div class="stat-card highlight">
-            <span class="label">Högsta poäng hittills</span>
-            <span class="value" id="bestScore">0</span>
+          <div class="stat-card highlight stat-card--double">
+            <div class="stat-block">
+              <span class="label">Högsta poäng hittills</span>
+              <span class="value" id="bestScore">0</span>
+            </div>
+            <div class="stat-block">
+              <span class="label">Utforskning ε</span>
+              <span class="value" id="epsilonValue">0.30</span>
+            </div>
           </div>
         </div>
       </div>
@@ -63,6 +72,7 @@
     <section class="version-history">
       <h2>Versionshistorik</h2>
       <ul>
+        <li><strong>v 1.2:</strong> Visualisering av bästa funna rutt vid paus, visning av ε-värdet och mindre gränssnittsjusteringar.</li>
         <li><strong>v 1.1:</strong> Förbättrad layout, korrigerad belöningshantering och tillagd versionslogg.</li>
         <li><strong>v 1.0:</strong> Första versionen med visualisering av Q-learning i gridvärlden.</li>
       </ul>

--- a/style.css
+++ b/style.css
@@ -125,6 +125,11 @@ button.danger {
   gap: 1.25rem;
 }
 
+.grid-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .grid-panel h2,
 .chart-section h2 {
   margin-top: 0;
@@ -162,6 +167,29 @@ button.danger {
 
 .cell span {
   pointer-events: none;
+}
+
+.path-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.path-overlay.visible {
+  opacity: 1;
+}
+
+.path-overlay polyline {
+  fill: none;
+  stroke: #ff4d4f;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 6px rgba(255, 77, 79, 0.6));
 }
 
 .legend {
@@ -212,6 +240,19 @@ button.danger {
   align-items: baseline;
   box-shadow: inset 0 2px 6px rgba(125, 138, 230, 0.08);
   flex: 1 1 180px;
+}
+
+.stat-card--double {
+  gap: 1.25rem;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.stat-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 120px;
 }
 
 .stat-card.highlight {


### PR DESCRIPTION
## Summary
- bump the interface to version 1.2 and expose the exploration constant next to the best score
- capture episode paths and render the best-performing route as a red SVG overlay while training is paused
- tweak styling to host the overlay, dual-value stat card, and document the new version features

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d54ed44e0c832b9f7cf38435f73254