### PR TITLE
Update UI for version 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Förstärkningsinlärning – Gridvärld v 1.2</title>
+  <title>Förstärkningsinlärning – Gridvärld v 1.3</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <main class="app-container">
     <header>
-      <h1>Robotens förstärkningsinlärning v 1.2</h1>
+      <h1>Robotens förstärkningsinlärning v 1.3</h1>
       <p>Utforska hur en enkel Q-learning agent hittar den optimala vägen genom rutnätet.</p>
     </header>
 
@@ -34,8 +34,8 @@
         </div>
         <div class="legend">
           <span><span class="legend-icon start">🏠</span>Start</span>
-          <span><span class="legend-icon goal">💎</span>Mål</span>
-          <span><span class="legend-icon hazard">💀</span>Fara</span>
+          <span><span class="legend-icon goal">💎</span>Mål (+10p)</span>
+          <span><span class="legend-icon hazard">💀</span>Fara (-10p)</span>
           <span><span class="legend-icon wall">🚧</span>Hinder</span>
           <span><span class="legend-icon robot">🤖</span>Robot</span>
         </div>
@@ -48,15 +48,13 @@
             <span class="label">Poäng denna episod</span>
             <span class="value" id="currentScore">0</span>
           </div>
-          <div class="stat-card highlight stat-card--double">
-            <div class="stat-block">
-              <span class="label">Högsta poäng hittills</span>
-              <span class="value" id="bestScore">0</span>
-            </div>
-            <div class="stat-block">
-              <span class="label">Utforskning ε</span>
-              <span class="value" id="epsilonValue">0.30</span>
-            </div>
+          <div class="stat-card">
+            <span class="label">Högsta poäng hittills</span>
+            <span class="value" id="bestScore">0 (episod –)</span>
+          </div>
+          <div class="stat-card">
+            <span class="label">Utforskning ε</span>
+            <span class="value" id="epsilonValue">0.30</span>
           </div>
         </div>
       </div>
@@ -69,14 +67,6 @@
       </div>
     </section>
 
-    <section class="version-history">
-      <h2>Versionshistorik</h2>
-      <ul>
-        <li><strong>v 1.2:</strong> Visualisering av bästa funna rutt vid paus, visning av ε-värdet och mindre gränssnittsjusteringar.</li>
-        <li><strong>v 1.1:</strong> Förbättrad layout, korrigerad belöningshantering och tillagd versionslogg.</li>
-        <li><strong>v 1.0:</strong> Första versionen med visualisering av Q-learning i gridvärlden.</li>
-      </ul>
-    </section>
   </main>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -38,6 +38,7 @@ let qTable = [];
 let currentEpisode = 0;
 let currentScore = 0;
 let bestScore = -Infinity;
+let bestScoreEpisode = null;
 let isTraining = false;
 let isPaused = false;
 let episodeActive = false;
@@ -421,7 +422,8 @@ function finalizeEpisode(score) {
 
   if (score > bestScore) {
     bestScore = score;
-    bestScoreEl.textContent = bestScore.toFixed(1);
+    bestScoreEpisode = currentEpisode;
+    updateBestScoreDisplay();
     bestPath = currentEpisodePath.map(position => ({ ...position }));
     if (isPaused) {
       renderBestPath();
@@ -467,6 +469,7 @@ function resetTraining() {
   currentEpisode = 0;
   currentScore = 0;
   bestScore = -Infinity;
+  bestScoreEpisode = null;
   bestPath = null;
   currentEpisodePath = [];
   scores = [];
@@ -481,7 +484,7 @@ function resetTraining() {
   chart.update();
   episodeCounter.textContent = "0";
   currentScoreEl.textContent = "0";
-  bestScoreEl.textContent = "0";
+  updateBestScoreDisplay();
   robotPos = { ...startPos };
   initQTable();
   createGrid();
@@ -505,6 +508,7 @@ initQTable();
 updateSpeedLabel();
 syncChartHeight();
 updateEpsilonDisplay();
+updateBestScoreDisplay();
 window.addEventListener("resize", () => {
   syncChartHeight();
   if (isPaused) {
@@ -517,4 +521,12 @@ window.addEventListener("resize", () => {
 function updateEpsilonDisplay() {
   if (!epsilonValueEl) return;
   epsilonValueEl.textContent = epsilon.toFixed(2);
+}
+
+function updateBestScoreDisplay() {
+  if (!bestScoreEl) return;
+  const hasBestScore = bestScore !== -Infinity;
+  const scoreText = hasBestScore ? bestScore.toFixed(1) : "0";
+  const episodeText = hasBestScore && bestScoreEpisode !== null ? bestScoreEpisode : "–";
+  bestScoreEl.textContent = `${scoreText} (episod ${episodeText})`;
 }


### PR DESCRIPTION
## Summary
- bump the interface version references to 1.3 and remove the obsolete versionshistorik section
- adjust legend labels with point values and separate the best score and epsilon status cards with a shared white style
- enhance the best score display to include the episode in which it was achieved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d556f2e1d8832b954b6e50410e5e51