### PR TITLE
Adjust speed control placement and best score label

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,12 +17,12 @@
     <section class="controls">
       <div class="button-group">
         <button id="startBtn" class="primary">Starta</button>
+        <div class="speed-control">
+          <label for="speedSlider">Hastighet: <span id="speedLabel">Bas</span></label>
+          <input type="range" id="speedSlider" min="1" max="10" value="1" />
+        </div>
         <button id="pauseBtn" class="secondary">Pausa</button>
         <button id="resetBtn" class="danger">Starta om</button>
-      </div>
-      <div class="speed-control">
-        <label for="speedSlider">Hastighet: <span id="speedLabel">Bas</span></label>
-        <input type="range" id="speedSlider" min="1" max="10" value="1" />
       </div>
     </section>
 
@@ -50,7 +50,7 @@
           </div>
           <div class="stat-card">
             <span class="label">Högsta poäng hittills</span>
-            <span class="value" id="bestScore">0 (episod –)</span>
+            <span class="value" id="bestScore">0 (Ep –)</span>
           </div>
           <div class="stat-card">
             <span class="label">Utforskning ε</span>

--- a/script.js
+++ b/script.js
@@ -528,5 +528,5 @@ function updateBestScoreDisplay() {
   const hasBestScore = bestScore !== -Infinity;
   const scoreText = hasBestScore ? bestScore.toFixed(1) : "0";
   const episodeText = hasBestScore && bestScoreEpisode !== null ? bestScoreEpisode : "–";
-  bestScoreEl.textContent = `${scoreText} (episod ${episodeText})`;
+  bestScoreEl.textContent = `${scoreText} (Ep ${episodeText})`;
 }

--- a/style.css
+++ b/style.css
@@ -52,7 +52,13 @@ header p {
 
 .button-group {
   display: flex;
+  align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button-group > * {
+  flex-shrink: 0;
 }
 
 button {
@@ -86,10 +92,14 @@ button.danger {
   color: var(--text);
 }
 
+.speed-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .speed-control label {
-  display: block;
   font-weight: 600;
-  margin-bottom: 0.3rem;
 }
 
 #speedSlider {


### PR DESCRIPTION
## Summary
- place the speed slider immediately to the right of the start button for a tighter control layout
- update the best score display to show the episode number prefixed with "Ep"

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68d586a300e0832bb41c56f763fb50a9