### PR TITLE
Add apple bonus and grid editing tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Förstärkningsinlärning – Gridvärld v 1.4</title>
+  <title>Förstärkningsinlärning – Gridvärld v 2.1</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <main class="app-container">
     <header>
-      <h1>Robotens förstärkningsinlärning v 1.4</h1>
+      <h1>Robotens förstärkningsinlärning v 2.1</h1>
       <p>Utforska hur en enkel Q-learning agent hittar den optimala vägen genom rutnätet.</p>
     </header>
 
@@ -36,9 +36,11 @@
           <span><span class="legend-icon start">🏠</span>Start</span>
           <span><span class="legend-icon goal">💎</span>Mål (+10p)</span>
           <span><span class="legend-icon hazard">💀</span>Fara (-10p)</span>
+          <span><span class="legend-icon apple">🍎</span>Äpple (+1p)</span>
           <span><span class="legend-icon wall">🚧</span>Hinder</span>
           <span><span class="legend-icon robot">🤖</span>Robot</span>
         </div>
+        <p class="grid-note">Bonus (+1p)</p>
         <div class="status-panel">
           <div class="stat-card">
             <span class="label">Aktuell episod</span>

--- a/style.css
+++ b/style.css
@@ -87,6 +87,11 @@ button.secondary {
   color: var(--text);
 }
 
+#pauseBtn {
+  min-width: 120px;
+  text-align: center;
+}
+
 button.danger {
   background: var(--accent-2);
   color: var(--text);
@@ -168,11 +173,16 @@ button.danger {
   font-size: 1.8rem;
   box-shadow: inset 0 2px 4px rgba(125, 138, 230, 0.12);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
 }
 
 .cell.robot-active {
   box-shadow: 0 0 18px rgba(255, 209, 102, 0.8);
   transform: scale(1.05);
+}
+
+.cell.start-cell {
+  cursor: default;
 }
 
 .cell span {
@@ -239,6 +249,13 @@ button.danger {
 .legend-icon.hazard { background: #ffe0e0; }
 .legend-icon.wall { background: #fef3c7; }
 .legend-icon.robot { background: #dbeafe; }
+.legend-icon.apple { background: #ffe8d6; }
+
+.grid-note {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+  color: rgba(47, 42, 74, 0.75);
+}
 
 .stat-card {
   background: rgba(255, 255, 255, 0.82);


### PR DESCRIPTION
## Summary
- bump the app version label to 2.1 and extend the legend with the new apple bonus note
- enable editing of grid cells to place apples, walls, hazards, and diamonds while keeping at least one terminal tile
- add the new apple reward logic to the Q-learning loop so apples grant +1 point without ending the episode
- polish UI by capitalizing the pause button resume text, fixing its width, and showing a bonus explanation under the grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a9b56000832babef5e312c09315b