### PR TITLE
Add blank cell option and restore apples across episodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Förstärkningsinlärning – Gridvärld v 2.1</title>
   <link rel="stylesheet" href="style.css" />
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🤖</text></svg>"
+  />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow grid cell editing to cycle through an empty state so tiles can be cleared
- track apple placements so they respawn at the start of each episode and after resets
- add a robot emoji favicon to the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5addcfa44832ba469ce024c49c85e