### PR TITLE
Add apple mask to Q-learning state

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             name="appleRewardInput"
             min="0"
             step="0.5"
-            value="3"
+            value="10"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- track the remaining apples with a bitmask so the Q-table state covers position plus apple availability
- rebuild the apple index on layout changes, reset the mask each episode, and guard episodes with a max step limit
- tune training defaults by raising apple rewards, using optimistic Q initialisation, and adjusting epsilon decay

## Testing
- not run (web app)


------
https://chatgpt.com/codex/tasks/task_e_68d64136cca8832bb04897aa32e228f6