### PR TITLE
Align hyperparameter inputs with labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
             <h3>Justera hyperparametrar</h3>
             <p class="hyperparameter-note">Starta om för att ge effekt.</p>
             <div class="hyperparameter-control">
-              <label for="gammaInput">Framtidsvikt: γ</label>
+              <label for="gammaInput">Framtidsvikt γ</label>
               <input
                 type="number"
                 id="gammaInput"

--- a/style.css
+++ b/style.css
@@ -510,6 +510,7 @@ button.danger {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  align-items: flex-start;
 }
 
 .hyperparameter-control label {
@@ -527,8 +528,9 @@ button.danger {
   background: rgba(255, 255, 255, 0.92);
   color: rgba(110, 70, 30, 0.95);
   box-shadow: inset 0 2px 4px rgba(255, 170, 120, 0.25);
-  width: 100%;
-  text-align: center;
+  width: 13ch;
+  max-width: 100%;
+  text-align: left;
 }
 
 .hyperparameter-control input:focus {


### PR DESCRIPTION
## Summary
- remove the colon from the gamma label so it reads "Framtidsvikt γ"
- reduce the width of the hyperparameter inputs and left-align them with their labels

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d78b416110832ba6c5a35eaa134be1